### PR TITLE
Fix errors in decoding and extent calculation implementations

### DIFF
--- a/example/geohash.dart
+++ b/example/geohash.dart
@@ -4,4 +4,3 @@
 library geohash.example;
 
 import 'package:geohash/geohash.dart';
-

--- a/lib/src/geohash_base.dart
+++ b/lib/src/geohash_base.dart
@@ -82,7 +82,7 @@ class Geohash {
       {final int codeLength: 12}) {
     if (codeLength > 20 || (identical(1.0, 1) && codeLength > 12)) {
       //Javascript can only handle 32 bit ints reliably.
-      throw new ArgumentError(
+      throw ArgumentError(
           'latitude and longitude are not precise enough to encode $codeLength characters');
     }
     final latitudeBase2 = (latitude + 90) * (pow(2.0, 52) / 180);
@@ -129,7 +129,7 @@ class Geohash {
     final codeLength = geohash.length;
     if (codeLength > 20 || (identical(1.0, 1) && codeLength > 12)) {
       //Javascript can only handle 32 bit ints reliably.
-      throw new ArgumentError(
+      throw ArgumentError(
           'latitude and longitude are not precise enough to encode $codeLength characters');
     }
     var latitudeInt = 0;
@@ -140,8 +140,8 @@ class Geohash {
       int thisSequence;
       try {
         thisSequence = _base32CharToNumber[character];
-      } catch (error) {
-        throw new ArgumentError('$geohash was not a geohash string');
+      } on Exception catch (_) {
+        throw ArgumentError('$geohash was not a geohash string');
       }
       final bigBits = ((thisSequence & 16) >> 2) |
           ((thisSequence & 4) >> 1) |
@@ -170,7 +170,7 @@ class Geohash {
       final height = latitudeDiff * (180 / pow(2.0, 52));
       final width = longitudeDiff * (360 / pow(2.0, 52));
       return Rectangle<double>(
-          latitude + height, longitude, height.toDouble(), width.toDouble());
+          latitude, longitude, height.toDouble(), width.toDouble());
     }
 
     longitudeInt = longitudeInt << (52 - longitudeBits);
@@ -181,15 +181,15 @@ class Geohash {
     final longitude = longitudeInt.toDouble() * (360 / pow(2.0, 52)) - 180;
     final height = latitudeDiff.toDouble() * (180 / pow(2.0, 52));
     final width = longitudeDiff.toDouble() * (360 / pow(2.0, 52));
-    return Rectangle<double>(latitude + height, longitude, height, width);
+    return Rectangle<double>(latitude, longitude, height, width);
     //I know this is backward, but it's because lat/lng are backwards.
   }
 
-  /// Get a single number that is the center of a specific geohas rectangle.
+  /// Get a single number that is the center of a specific geohash rectangle.
   static Point<double> decode(String geohash) {
     final extents = getExtents(geohash);
     final x = extents.left + extents.width / 2;
-    final y = extents.bottom + extents.height / 2;
-    return new Point<double>(x, y);
+    final y = extents.top + extents.height / 2;
+    return Point<double>(x, y);
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: geohash
 description: A simple geohashing library for dart
-version: 0.2.1
+version: 1.0.0
 author: Adam Stark <llamadonica@gmail.com>
 homepage: https://github.com/llamadonica/dart-geohash
 

--- a/test/geohash_test.dart
+++ b/test/geohash_test.dart
@@ -29,5 +29,10 @@ void main() {
               .distanceTo(Geohash.decode('9qcehwvbqhp8')),
           closeTo(0.0, 1e-6));
     });
+    test('Wikipedia example', () {
+      final decodedCoordinates = Geohash.decode('ezs42');
+      final expectedResult = const Point<double>(42.605, -5.603);
+      expect(decodedCoordinates.distanceTo(expectedResult), closeTo(0.0, 1e-4));
+    });
   });
 }


### PR DESCRIPTION
Dart math's coordinate system used for points/rectangles assumes that a rectangle's `bottom` is it's `top + height`. Current implementation added another `height / 2` to that to calculate the center point of a tile.

This PR fixes that issue and adds a test case for this behaviour.